### PR TITLE
Use `relative_url` to fix relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # SPA website
 
-To run locally: `bundle exec jekyll serve`, and it will be at [localhost:4000](localhost:4000).
+To run locally: `bundle exec jekyll serve`. The output of that command will tell you where the site is running locally (something like `localhost:4000/$conference_year`).

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ kramdown:
 
 exclude: [vendor, README.md, Gemfile*, scripts, deploy_rsa*]
 
+baseurl: /tmp
+
 conference:
   current_year: 2017
   conference_year: spa2018

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
       <script src="html5shiv.min.js"></script>
     <![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href= "/spa.css" type="text/css">
+    <link rel="stylesheet" href= "{{ '/spa.css' | relative_url }}" type="text/css">
 </head>
 
   {% if page.url == "/" %}
@@ -25,8 +25,8 @@
 
 <header><div>
   <h1>
-    <img alt="BCS" src="/images/bcslogo.png" width="65" height="81">
-    <a href="/">{{ site.conference.name_html }}</a>
+    <img alt="BCS" src="{{ '/images/bcslogo.png' | relative_url }}" width="65" height="81">
+    <a href="{{ '/' | relative_url }}">{{ site.conference.name_html }}</a>
   </h1>
 
   {% if page.url == "/" %}

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,22 +1,22 @@
 <nav>
   <ul>
     <li>
-      <a href="/sponsor.html"><span>Sponsor Us</span></a>
+      <a href="{{ '/sponsor.html' | relative_url }}"><span>Sponsor Us</span></a>
     </li>
     <li>
-      <a href="/lead-a-session.html"><span>Lead a Session</span></a>
+      <a href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a>
     </li>
     <li>
-      <a href="/organisers.html"><span>Organisers</span></a>
+      <a href="{{ '/organisers.html' | relative_url }}"><span>Organisers</span></a>
     </li>
     <li>
-      <a href="/location.html"><span>Location</span></a>
+      <a href="{{ '/location.html' | relative_url }}"><span>Location</span></a>
     </li>
     <li>
-      <a href="/previousconferences.html"><span>Previous Conferences</span></a>
+      <a href="{{ '/previousconferences.html' | relative_url }}"><span>Previous Conferences</span></a>
     </li>
     <li>
-      <a href="/code-of-conduct.html"><span>Code of Conduct</span></a>
+      <a href="{{ '/code-of-conduct.html' | relative_url }}"><span>Code of Conduct</span></a>
     </li>
     <li>
       <a href="http://spaconference.org/scripts/myprofile.php"><span>My Spa</span></a>

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ layout: page
 
 <section><div class="inner">
 <h1>The location</h1>
-<img src="/images/bcs-london.jpg" width="300" height="300" class="round"/>
+<img src="{{ '/images/bcs-london.jpg' | relative_url }}" width="300" height="300" class="round"/>
 <p>{{ site.conference.name_html }} will take place in the excellent facilities provided by The BCS’s London office. Located in the heart of London’s West End on Southampton Street, just a few moments walk from Covent Garden, the venue is easy to reach by public transport and is located near a wide range of hotels.</p>
  <a href="/location.html">More about the location.</a></div></section>
 

--- a/location.md
+++ b/location.md
@@ -5,7 +5,7 @@ layout: page
 
 {{ site.conference.name_html }} will take place in the BCS's London Office.
 
-<img style="margin: 15px 3px 15px 15px; float: right;" src="/images/BCSLondon.jpg" alt="BCS London entrance with clock" width="141" height="400" />
+<img style="margin: 15px 3px 15px 15px; float: right;" src="{{ '/images/BCSLondon.jpg' | relative_url }}" alt="BCS London entrance with clock" width="141" height="400" />
 
 <address>BCS London Office
 First Floor


### PR DESCRIPTION
In `da71c2a` I removed the `base` tag and made the links relative so that the site would work locally, but that only works locally because the site is at the root of the domain. On the server, this site sits in a sub-directory (e.g. `spa2018`) so these links, relative to the root, do not work on the server.

This commit fixes that by setting a `baseurl` (currently `/tmp/` but once the site is active that will be the actual directory we want to deploy to), and using Jekyll's `relative_url` filter to make URLs do the right thing.

Documentation here: https://jekyllrb.com/docs/templates/

Useful blog post (though it trails off in the middle of a thought...), here: https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/.