### PR TITLE
Add lead a session page & supplementary pages

### DIFF
--- a/_includes/lead-a-session-nav.html
+++ b/_includes/lead-a-session-nav.html
@@ -1,0 +1,6 @@
+<ul>
+  <li><a{% if page.url == '/lead-a-session.html' %} class="menuactive" {% endif %} href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
+  <li><a{% if page.url == '/themes.html' %} class="menuactive" {% endif %} href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
+  <li><a{% if page.url == '/formats.html' %} class="menuactive" {% endif %} href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
+  <li><a{% if page.url == '/submission-stages.html' %} class="menuactive" {% endif %} href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
+</ul>

--- a/_includes/lead-a-session-nav.html
+++ b/_includes/lead-a-session-nav.html
@@ -1,6 +1,6 @@
 <ul>
-  <li><a{% if page.url == '/lead-a-session.html' %} class="menuactive" {% endif %} href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
-  <li><a{% if page.url == '/themes.html' %} class="menuactive" {% endif %} href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
+  <li><a{% if page.url == '/lead-a-session.html' %} class="menuactive" {% endif %} href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a session</span></a></li>
+  <li><a{% if page.url == '/themes.html' %} class="menuactive" {% endif %} href="{{ '/themes.html' | relative_url }}"><span>Conference themes</span></a></li>
   <li><a{% if page.url == '/formats.html' %} class="menuactive" {% endif %} href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
   <li><a{% if page.url == '/submission-stages.html' %} class="menuactive" {% endif %} href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
 </ul>

--- a/_includes/previous-conferences-nav.html
+++ b/_includes/previous-conferences-nav.html
@@ -1,0 +1,23 @@
+<ul>
+  <li><a href="http://spaconference.org/spa2017/"><span>SPA2017</span></a></li>
+  <li><a href="http://spaconference.org/spa2016/"><span>SPA2016</span></a></li>
+  <li><a href="http://spaconference.org/spa2015/"><span>SPA2015</span></a></li>
+  <li><a href="http://spaconference.org/spa2014/"><span>SPA2014</span></a></li>
+  <li><a href="http://spaconference.org/spa2013/"><span>SPA2013</span></a></li>
+  <li><a href="http://spaconference.org/spa2012/"><span>SPA2012</span></a></li>
+  <li><a href="http://spaconference.org/spa2011/"><span>SPA2011</span></a></li>
+  <li><a href="http://spaconference.org/spa2010/"><span>SPA2010</span></a></li>
+  <li><a href="http://spaconference.org/spa2009/"><span>SPA2009</span></a></li>
+  <li><a href="http://spaconference.org/spa2008/"><span>SPA2008</span></a></li>
+  <li><a href="http://spaconference.org/spa2007/"><span>SPA2007</span></a></li>
+  <li><a href="http://spaconference.org/spa2006/"><span>SPA2006</span></a></li>
+  <li><a href="http://spaconference.org/spa2005/"><span>SPA2005</span></a></li>
+  <li><a href="http://spaconference.org/ot2004/"><span>OT2004</span></a></li>
+  <li><a href="http://spaconference.org/ot2003/"><span>OT2003</span></a></li>
+  <li><a href="http://spaconference.org/ot2002/"><span>OT2002</span></a></li>
+  <li><a href="http://spaconference.org/ot2001/"><span>OT2001</span></a></li>
+  <li><a href="http://spaconference.org/ot2000/index.htm"><span>OT2000</span></a></li>
+  <li><a href="http://spaconference.org/ot99/"><span>OT99</span></a></li>
+  <li><a href="http://spaconference.org/ot98/"><span>OT98</span></a></li>
+  <li><a href="http://spaconference.org/ot97/"><span>OT97</span></a></li>
+</ul>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@
 
 {% include header.html %}
 
-  <div id="main"{% if page.has-nav == true %} class="has-nav"{% endif %}>
+  <div id="main"{% if page.has-nav %} class="has-nav"{% endif %}>
 
     {% if page.url != "/" %}
       <header><h1 class="inner">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@
 
 {% include header.html %}
 
-  <div id="main"{% if page.has-nav == 'true' %}class="has-nav"{% endif %}>
+  <div id="main"{% if page.has-nav == true %} class="has-nav"{% endif %}>
 
     {% if page.url != "/" %}
       <header><h1 class="inner">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,6 +12,12 @@
       <div class="inner">
     {% endif %}
 
+    {% if page.has-nav %}
+      <nav>
+        {% include {{ page.has-nav }}-nav.html %}
+      </nav>
+    {% endif %}
+
     <main>
       {{ content }}
     </main>

--- a/formats.md
+++ b/formats.md
@@ -1,17 +1,8 @@
 ---
 title: Lead a session at SPA
 layout: page
-has-nav: true
+has-nav: lead-a-session
 ---
-
-<nav>
-  <ul>
-    <li><a href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
-    <li><a href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
-    <li class="menuactive"><a class="menuactive" href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
-    <li><a href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
-  </ul>
-</nav>
 
 <h1>Session formats</h1>
 <p>You can propose whatever sort of session you want. That is why the box on the submission form is free text. </p>

--- a/formats.md
+++ b/formats.md
@@ -1,0 +1,58 @@
+---
+title: Lead a session at SPA
+layout: page
+has-nav: true
+---
+
+<nav>
+  <ul>
+    <li><a href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
+    <li><a href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
+    <li class="menuactive"><a class="menuactive" href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
+    <li><a href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
+  </ul>
+</nav>
+
+<h1>Session formats</h1>
+<p>You can propose whatever sort of session you want. That is why the box on the submission form is free text. </p>
+<p>Below is a guide to some of the session types that have traditionally made up the conference, but don't feel constrained to stick to these. Obviously when we put together the final programme we'll need to impose some sort of structure in terms of timings etc, but submit whatever you like and we'll do our best to make up a programme schedule from the best proposals.</p>
+
+<h2 id="WS">Workshop</h2>
+<h3>75 or 150 minutes</h3>
+<p>Interactive, structured session in which participants work on a topic and try to produce some conclusions (which are made available to other SPA participants) or at least try to advance their thinking and ideas on the topic.<br /> <br /> Workshops may take many different forms and submitters are free to propose their own structure and process. It is very important that proposals are explicit about the process that will be followed.</p>
+
+<h2 id="TU">Tutorial</h2>
+<h3>75 or 150 minutes</h3>
+<p>An instructor led session on a clearly focussed topic, probably introducing the audience to a new technique or technology. For example a tutorial could be aimed at experienced project managers, or introduce developers to a new programming language.</p>
+<p>You should have a clear idea of what insights your participants will take away, and why they will find these interesting. While tutorials are expected to contain a certain amount of formal presentation, you should try to incorporate some interaction between participants, for example by including practical exercises.</p>
+
+<h2 id="LT">Long Tutorial</h2>
+<h3>Up to 330 minutes</h3>
+<p>A longer, interactive learning session on a clearly focussed topic, normally run on Sunday before the main conference begins. Contains some presentation material, but must also incorporate practical exercises or interaction between participants.</p>
+
+<h2 id="GB">Goldfish Bowl</h2>
+<h3>Normally 75 minutes</h3>
+<p>A structured discussion format. Goldfish bowls generally require an initial seed group of four or five specially invited participants, with the rest of the participants beginning as the audience and then swapping in and out with the participants. <br /> <br /> A goldfish bowl provides an effective means of exploring the breadth of opinion on a given topic. The session is started by a small discussion group of specially invited participants, with the rest of the participants forming an audience. Spare places in the discussion group are available, and members of the audience may take up these places when they feel they have a contribution to make. Members of the discussion group leave their places when they have had their say, making room for new participants. The session should produce documentary output of the conclusions reached, typically in the form of a poster.</p>
+
+<h2 id="CS">Case Study</h2>
+<h3>Normally 75 minutes</h3>
+<p>A case study session aims to describe real-life experiences and lessons learnt in a real project, maybe when trying to implement a particular technique. The experiences described can be drawn from any aspect of software development or related projects. What went wrong and why (this is the most interesting part!); what went well and why; what lessons have been learnt from the experience?</p>
+
+<h2 id="SI">Simulation</h2>
+<h3>75 or 150 minutes</h3>
+<p>Reflection on or experimentation with complex real-world environments facilitated by means of a simulation, role-play or games. <br /> <br /> Given the complexity of the real-world environment in which we practice software, it is often not possible to reflect clearly on the way we work or to expweriment with new approaches. Using simulations and games howwever allows us to think about these situations with increased clarity. A simulation leader will be responsible for producing a clear and concise summary of the purpose, rules, and assumptions of the game. Some work on reflecting on the results of the game and its implications for real-world practice should also be included. The output from the sessions is likely to include both summary results from the simulation and a summary of its real-world implications.</p>
+
+<h2 id="TT">Think Tank</h2>
+<h3>Normally 75 minutes</h3>
+<p>A small group of people meeting to solve a particular problem or to find an agreed position on some issue. Think-tank sessions are intensive, focused and produce concrete outputs. <br /> <br /> Think tanks should produce concrete output in the form of a poster for other conference participants. The session leader is responsible for the process of the session, for any materials that may be needed, and for ensuring that the poster is produced.</p>
+
+<h2 id="WG">Informal Sessions</h2>
+<p>There's also the chance just to break out an informal discussion about a topic close to your heart. Perhaps try one of these:</p>
+<ul>
+<li><em>Sofa Sessions</em>: Laid-back chats, discussions and brain-storming on a pre-arranged topic. </li>
+<li><em>Virtual Sessions</em>: A session taking place in virtual reality making use of the internet, participants' laptops and the wireless network.</li>
+<li><em>On the Edge Sessions</em>: Experiments in ways of working, interacting and transferring knowledge.</li>
+<li><em>Multi-Topic Sessions</em>: Sessions that contain a number of topics, devoting a short time to each, in order to keep the level of energy and interest high throughout.</li>
+</ul>
+
+<p>There will also be opportunities to organise <strong>Birds of a Feather</strong> (BoF) sessions during the conference. These informal, focused sessions do not need to be proposed in advance but will be solicited from registered participants a few weeks before the conference begins as well as during the conference itself.</p>

--- a/lead-a-session.md
+++ b/lead-a-session.md
@@ -1,5 +1,51 @@
 ---
 title: Lead a session at SPA
 layout: page
+has-nav: true
 ---
-<p>The best way to get involved in SPA is to lead a session, and we'd love you to take part. The call for papers will open on {{ site.conference.cfp_open_date }}.</p>
+
+<nav>
+  <ul>
+    <li class="menuactive"><a class="menuactive" href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
+    <li><a href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
+    <li><a href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
+    <li><a href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
+  </ul>
+</nav>
+
+<h1>Propose a session</h1>
+<p>SPA Software in Practice is about practitioners from any aspect of software development - technology, people and process - sharing their thoughts and knowledge, and learning together.</p>
+<p>All the sessions are interactive - everyone can be an active participant and learn by doing.</p>
+
+<h2>What are we looking for?</h2>
+<p>We welcome a wide variety of perspectives on all aspects of software development - new ideas, old ideas rediscovered, creativity, the unexpected, reflection and fun. In the past we’ve had sessions on programming languages, tools, techniques, design, architecture, testing, coaching, team dynamics, pairing and process.</p>
+<p>We’ve also had some great sessions on topics you might not expect at a software conference, like sketching, speed reading, and education. We really like sessions like this too - they give us more opportunities to think about and try a wide range of things.</p>
+<p>At SPA you can experiment and try something new, or bring a session you’ve perfected elsewhere - we value both. All submissions get feedback to help them improve, and accepted sessions will be assigned a shepherd to help with preparation so we’ll support you along the way.</p>
+<p>You can get an idea of the sort of sessions that have run previously from the websites for <a href="{{ '/previous-conferences.html' | relative_url }}">previous years' conferences</a>.</p>
+<p>But don't be constrained by any of these ideas; maybe you've got something totally new to bring. We'd like to hear it.</p>
+<p>We’d love to see in your proposal how you’ll make your session interactive and get participants involved. You can get some ideas of ways to do that from <a href="{{ 'formats.html' | relative_url }}">our formats page</a> or propose anything else you like.</p>
+
+<h2>Who do we want to hear from?</h2>
+<p>Anyone involved in software development!</p>
+<p>We particularly encourage speakers who are new to presenting at SPA. If you submit early, our feedback process will allow you to tune your proposal before the final review stage.</p>
+
+<h2>The submission and selection process</h2>
+<p>To submit your proposal, complete the <a href="http://spaconference.org/scripts/makeproposal.php">form on the website</a>.</p>
+<p>Your submission is completely anonymous right up until we have the draft programme - then we just check that you're not down to do two talks at once.</p>
+<p>All sessions submitted by 10pm on 7th January 2018 will receive feedback to help improve the proposal.</p>
+<p>Submissions can be edited until the hard deadline of 4th February 2018.</p>
+<p>The submission and selection process is described in more detail <a href="{{ '/submission-stages.html' | relative_url }}">here</a>.</p>
+
+<h2>What we offer</h2>
+<p>We will help you make your session the best it can be, both through our feedback process prior to the submissions deadline and our shepherding process if your session is accepted. More detail on these stages is <a href="{{ '/submission-stages.html' | relative_url }}">here</a>.</p>
+<p>The first two named presenters of each accepted session receive a free ticket to SPA. If you have already purchased a ticket before the programme is announced, you will receive a full refund. See <a href="{{ '/terms-and-conditions.html' | relative_url }}">here</a> for conditions.</p>
+<p>We do not pay accommodation costs or travel expenses for speakers because the conference is not run for profit and we do everything we can to keep costs down for attendees. However, if this will make the difference between whether you are able to present or not, please contact us to discuss it as we may be able to make a small bursary available.</p>
+
+<h2>Important dates</h2>
+<p>The conference: 2nd - 4th July 2018 - British Computer Society, London, UK</p>
+<p>Submissions submitted before 7th January 2018 will receive feedback and may be resubmitted.</p>
+<p>Submissions deadline: 4th February 2018</p>
+<p>Programme announced: 3rd April 2018</p>
+<p>If you're uncertain about whether to submit your idea, or have other queries, please feel free to get in touch with us at</p>
+<p><em>programme@spaconference.org</em></p>
+<p>Jenny Duckett and Melinda Seckington, Programme Chairs, SPA Software in Practice 2018</p>

--- a/lead-a-session.md
+++ b/lead-a-session.md
@@ -1,17 +1,8 @@
 ---
 title: Lead a session at SPA
 layout: page
-has-nav: true
+has-nav: lead-a-session
 ---
-
-<nav>
-  <ul>
-    <li class="menuactive"><a class="menuactive" href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
-    <li><a href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
-    <li><a href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
-    <li><a href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
-  </ul>
-</nav>
 
 <h1>Propose a session</h1>
 <p>SPA Software in Practice is about practitioners from any aspect of software development - technology, people and process - sharing their thoughts and knowledge, and learning together.</p>

--- a/organisers.md
+++ b/organisers.md
@@ -40,5 +40,3 @@ eval(unescape('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%6
 <td>Anna Shipman <em>Government Digital Service</em><br />
 <script language="javascript">eval(unescape('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%65%66%3d%22%6d%61%69%6c%74%6f%3a%77%65%62%73%69%74%65%40%73%70%61%63%6f%6e%66%65%72%65%6e%63%65%2e%6f%72%67%22%3e%77%65%62%73%69%74%65%40%73%70%61%63%6f%6e%66%65%72%65%6e%63%65%2e%6f%72%67%3c%2f%61%3e%27%29%3b'))</SCRIPT><NOSCRIPT><a href="http://www.quarella.co.uk/email/spamproof-noscript.html">[spam-blocked email address]</a></NOSCRIPT></td>
 </tr>
-</tbody>
-</table>

--- a/previous-conferences.md
+++ b/previous-conferences.md
@@ -1,33 +1,7 @@
 ---
 title: Previous conferences
 layout: page
-has-nav: true
+has-nav: previous-conferences
 ---
-
-<nav>
-  <ul>
-    <li><a href="http://spaconference.org/spa2017/"><span>SPA2017</span></a></li>
-    <li><a href="http://spaconference.org/spa2016/"><span>SPA2016</span></a></li>
-    <li><a href="http://spaconference.org/spa2015/"><span>SPA2015</span></a></li>
-    <li><a href="http://spaconference.org/spa2014/"><span>SPA2014</span></a></li>
-    <li><a href="http://spaconference.org/spa2013/"><span>SPA2013</span></a></li>
-    <li><a href="http://spaconference.org/spa2012/"><span>SPA2012</span></a></li>
-    <li><a href="http://spaconference.org/spa2011/"><span>SPA2011</span></a></li>
-    <li><a href="http://spaconference.org/spa2010/"><span>SPA2010</span></a></li>
-    <li><a href="http://spaconference.org/spa2009/"><span>SPA2009</span></a></li>
-    <li><a href="http://spaconference.org/spa2008/"><span>SPA2008</span></a></li>
-    <li><a href="http://spaconference.org/spa2007/"><span>SPA2007</span></a></li>
-    <li><a href="http://spaconference.org/spa2006/"><span>SPA2006</span></a></li>
-    <li><a href="http://spaconference.org/spa2005/"><span>SPA2005</span></a></li>
-    <li><a href="http://spaconference.org/ot2004/"><span>OT2004</span></a></li>
-    <li><a href="http://spaconference.org/ot2003/"><span>OT2003</span></a></li>
-    <li><a href="http://spaconference.org/ot2002/"><span>OT2002</span></a></li>
-    <li><a href="http://spaconference.org/ot2001/"><span>OT2001</span></a></li>
-    <li><a href="http://spaconference.org/ot2000/index.htm"><span>OT2000</span></a></li>
-    <li><a href="http://spaconference.org/ot99/"><span>OT99</span></a></li>
-    <li><a href="http://spaconference.org/ot98/"><span>OT98</span></a></li>
-    <li><a href="http://spaconference.org/ot97/"><span>OT97</span></a></li>
-  </ul>
-</nav>
 
 The conference is now in its 23rd year. You can see an archive of the previous conference sites dating back to 1997.

--- a/submission-stages.md
+++ b/submission-stages.md
@@ -1,17 +1,8 @@
 ---
 title: Lead a session at SPA
 layout: page
-has-nav: true
+has-nav: lead-a-session
 ---
-
-<nav>
-  <ul>
-    <li><a href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
-    <li><a href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
-    <li><a href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
-    <li class="menuactive"><a class="menuactive" href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
-  </ul>
-</nav>
 
 <h1>Submission stages</h1>
 <p>We have several stages after submission of proposals to help make the conference the best it can be.</p>

--- a/submission-stages.md
+++ b/submission-stages.md
@@ -1,0 +1,55 @@
+---
+title: Lead a session at SPA
+layout: page
+has-nav: true
+---
+
+<nav>
+  <ul>
+    <li><a href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
+    <li><a href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
+    <li><a href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
+    <li class="menuactive"><a class="menuactive" href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
+  </ul>
+</nav>
+
+<h1>Submission stages</h1>
+<p>We have several stages after submission of proposals to help make the conference the best it can be.</p>
+<h2>Feedback</h2>
+<p>The feedback stage is between 1st February and 28th February.</p>
+<p>During the feedback stage, we look at all the sessions that were submitted by 1st February and give them feedback to improve the submission and help make it the best it can be before it goes into the review stage. Sessions can be modified and resubmitted until the hard deadline of 28th February.</p>
+<p>We like each submission to have at least three pieces of feedback, so sessions will be ordered such that those with fewest feedback items are at the top but it's up to you which sessions you give feedback on. The more feedback you have time to give, the better, as it can be very helpful to session proposers, especially those not as familiar with SPA or new to presenting.</p>
+<p>At this stage, feedback is seen by the submitter themselves along with everyone else who has access, so it's important to be constructive. Don't forget that some of these people may be submitting to a conference for the first time ever, and your comments may be the first feedback they have received for their conference proposal. The point of this stage is to help submitters make the best proposal they can so ask them to clarify things, suggest modifications to the session, and of course, positive feedback is welcome!</p>
+<h2>Review</h2>
+<p>The review stage is between 28th February and 14th March.</p>
+<p>During the review stage we are closed to new submissions and existing submissions can't be edited, and this is the stage at which we decide which sessions we'd like to include in the conference. We mark submissions on four criteria:</p>
+<ol><ol>
+<li>Is this session worthwhile? For example, does it deliver tangible benefits to attendees?</li>
+<li>Will this session work? For example, will it achieve its stated goals in the time allotted, is the process clearly defined?</li>
+<li>Is the session exciting?</li>
+<li>Overall, do you think we should accept this session?</li>
+</ol></ol>
+<p>There is more context to help you answer these questions in the review form.</p>
+<p>We also make suggestions about the submissions - for example if we feel a session would be really good, but would require shepherding.</p>
+<p>Submitters do not get notified of the reviews, but if they have been involved in the feedback stages (and we encourage everyone to get involved) they will have access so it's still important to be constructive. And it would be bad form to down-vote a session you see as a competitor to one you have submitted!</p>
+<p>Again, ideally we would like every session to receive at least three reviews so that we can be sure the conference will have wide appeal.</p>
+<p>We encourage everyone to get involved in reviewing as well, even if you haven't been to SPA Conference before - the basis is whether you would like to attend the session or think it would be valuable.</p>
+<h2>Programme Meeting</h2>
+<p>The Programme Meeting will be in mid March 2016 in Central London. The exact timing and venue will be announced closer the time. If you would like to be involved in the Programme Meeting, please contact us.</p>
+<p>At this stage, submissions are still anonymous. We lay out cards with all the sessions and their scores, and formulate a draft programme. High scores are not the only thing we look at, as we want the programme to be as varied and balanced as possible, so we might not want four sessions on Node.js, for example. Those present are also given the opportunity to advocate for particular sessions, for example if it has received average reviews but they feel it would complement other sessions at the conference.</p>
+<p>We then reveal names to check that no-one has too many sessions in, or several at the same time.</p>
+<p>We will announce the programme on 1st April.</p>
+<h2>Shepherding</h2>
+<p>New presenters are offered the support of a shepherd, and any presenter can ask for one­. A shepherd is someone who has experience presenting, maybe at SPA, and ideally in a similar area to the session leaders. They offer advice and support to help people prepare their sessions, and may meet with the session leaders and perhaps help arrange dry-runs prior to the conference. (We do recommend that you have at least one dry-run of your session, regardless of whether the session is shepherded.)</p>
+<p>We are always looking for people to help shepherd, so please do let us know if you'd like to get involved in this.</p>
+<h2>Key dates</h2>
+<ol><ol>
+<ul>
+<li>Feedback: 1st February - 28th February</li>
+<li>Review: 28th February - 14th March</li>
+<li>Programme Meeting: TBC</li>
+<li>Shepherding: 1st April to conference.</li>
+</ul>
+</ol></ol>
+<p>If you have any questions or would like to be involved, please contact us:<em>programme@spaconference.org</em></p>
+<p>Paul Shannon and Alex Wilson, Programme Chairs, SPA2016.</p>

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -1,0 +1,29 @@
+---
+title: Terms and conditions
+layout: page
+---
+
+<h2>Leading a session</h2>
+<h3>Fees/Payment</h3>
+<p>The first two named presenters of an accepted session will qualify for free attendance at the conference. Session leaders are encouraged to attend the whole conference given the highly interactive nature of the event.</p>
+<h3>Conditions of inclusion in programme</h3>
+<ol>
+<li>Final acceptance of proposal will be at the complete discretion of the Programme Chair.</li>
+<li>By agreeing to have the session included in the programme the session leader is committing to participate in the shepherding process to ensure high session quality</li>
+</ol>
+
+<p>The session leader grants SPA the right to reproduce and distribute materials submitted for the session for the programme (online and printed). The copyright of the materials remains with the original copyright holder. Where copyright is held by a person other than the session leader, it is the session leader’s responsibility to ensure appropriate permission to use is secured.</p>
+
+<p>The conference committee has the absolute discretion to remove someone from the programme. This may happen if a session leader has not complied with these terms and conditions or the  <a href="http://spaconference.org/spa2018/code-of-conduct.html" title="Code of Conduct" >code of conduct</a>. If a session is removed from the programme, the session leaders will no longer be eligible for free attendance at the conference.</p>
+
+<h3>Use of your data</h3>
+<p>Those registered with this website are advised that information they provide will be held on computer databases for administrative purposes. If you are leading a session, the information you provide in your profile will be published on the SPA conference website.</p>
+
+<p>If you have consented to receive emails about SPA conference, you may be contacted about being involved in the conference (for example, reviewing sessions, or submitting a proposal) and about future conferences.</p>
+
+<p>Your information will not be shared with other groups.</p>
+
+<p>To find out what information is held about you or request deletion of all your information, please contact <a href="mailto:admin@spaconference.org">admin@spaconference.org</a>.</p>
+
+<h3>Other</h3>
+<p>The SPA Specialist Group is not responsible for the views or opinions expressed by individual session leaders, contributors to the SPA wiki, or any individuals who are not members of the executive committee.</p>

--- a/themes.md
+++ b/themes.md
@@ -1,17 +1,8 @@
 ---
 title: Lead a session at SPA
 layout: page
-has-nav: true
+has-nav: lead-a-session
 ---
-
-<nav>
-  <ul>
-    <li><a href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
-    <li class="menuactive"><a class="menuactive" href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
-    <li><a href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
-    <li><a href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
-  </ul>
-</nav>
 
 <h1>Conference Themes</h1>
 <p>We organise our conference sessions according to four broad themes: technology, people, process and practice.</p>

--- a/themes.md
+++ b/themes.md
@@ -1,0 +1,52 @@
+---
+title: Lead a session at SPA
+layout: page
+has-nav: true
+---
+
+<nav>
+  <ul>
+    <li><a href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a Session</span></a></li>
+    <li class="menuactive"><a class="menuactive" href="{{ '/themes.html' | relative_url }}"><span>Conference Themes</span></a></li>
+    <li><a href="{{ '/formats.html' | relative_url }}"><span>Formats</span></a></li> 
+    <li><a href="{{ '/submission-stages.html' | relative_url }}"><span>Submission stages</span></a></li>
+  </ul>
+</nav>
+
+<h1>Conference Themes</h1>
+<p>We organise our conference sessions according to four broad themes: technology, people, process and practice.</p>
+<h2>Technology</h2>
+<p>Technology is often where theory meets reality. Typical SPA technology sessions will be a hands-on exploration of a programming language, framework or technique. Sessions might explore emerging technologies or novel aspects and uses of established technologies.</p>
+<ul>
+    <li>Languages, libraries and frameworks (e.g. Swift, Haskell, Smalltalk, Ruby, Javascript, Scala, Clojure, ObjectiveC... etc).</li>
+    <li>Improvements in technologies for designing and testing software (e.g. Continous Integration, Automated Testing)</li>
+    <li>Enterprise Development Platforms (e.g. J2EE, .Net)</li>
+</ul>
+
+<h2>People</h2>
+<p>Software is an intensely human activity and sessions in this area typically explore how to organise and support people engaged in software development. Sessions might deal with:</p>
+<ul>
+    <li>Dynamics of software development</li>
+    <li>Communication, motivation and reflection</li>
+    <li>Problem solving and thinking models</li>
+    <li>Improving team dynamics</li>
+</ul>
+
+<h2>Process</h2>
+<p>Understanding how software can be developed and delivered predictably is a central issue. Sessions might examine:</p>
+<ul>
+    <li>Software and system architecture</li>
+    <li>Modelling techniques</li>
+    <li>Lean vs. Agile vs, plan-driven lifecycles</li>
+    <li>Stakeholders' needs</li>
+    <li>Software product lines</li>
+</ul>
+
+<h2>Practice</h2>
+<p>Do you have a valuable experience to share, be it positive or negative? Sharing experience is an important part of improving the state of practice. Sessions might deal with experience reports and case studies that:</p>
+<ul>
+    <li>Highlight the lessons learned</li>
+    <li>Patterns and pattern languages</li>
+    <li>Comparative experience (what we have learned or can learn from other disciplines)</li>
+    <li>Management of complex and changing environments</li>
+</ul>


### PR DESCRIPTION
This PR adds the lead a session page and supplementary pages, and also fixes up the internal page navigations (these occur in the lead a session page and the previous conferences page).